### PR TITLE
Add speaker diarization support

### DIFF
--- a/old/session_data.py
+++ b/old/session_data.py
@@ -12,6 +12,7 @@ class Word:
     start: float
     confidence: float
     color: str = "black"
+    speaker: Optional[str] = None
 
 @dataclass
 class Screenshot:


### PR DESCRIPTION
## Summary
- add optional `speaker` field to `Word`
- implement `diarize_speakers` using `pyannote.audio`
- attach speaker info to each word in `transcribe_file`

## Testing
- `python -m py_compile menuBD2.py old/session_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6842998740f88329a5ef2a9c624473cc