### PR TITLE
Improve chunked transcription reliability

### DIFF
--- a/chunk_transcriber.py
+++ b/chunk_transcriber.py
@@ -4,6 +4,7 @@ import wave
 import contextlib
 import tempfile
 import subprocess
+import shutil
 from typing import List
 
 
@@ -26,6 +27,10 @@ def split_wav_into_chunks(path: str, chunk_length: int = 300) -> List[str]:
     temp_dir = tempfile.mkdtemp(prefix="wav_chunks_")
     chunk_paths = []
 
+    # Verify that ffmpeg is installed and accessible
+    if not shutil.which("ffmpeg"):
+        raise RuntimeError("ffmpeg not found. Please install ffmpeg and ensure it is in your PATH.")
+
     for idx in range(num_chunks):
         start = idx * chunk_length
         output = os.path.join(temp_dir, f"chunk_{idx:04d}.wav")
@@ -40,7 +45,10 @@ def split_wav_into_chunks(path: str, chunk_length: int = 300) -> List[str]:
             str(chunk_length),
             output,
         ]
-        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
+        try:
+            subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, check=True)
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(f"ffmpeg failed: {e.stderr.decode(errors='ignore')}") from e
         chunk_paths.append(output)
     return chunk_paths
 
@@ -49,17 +57,24 @@ def transcribe_chunks(paths: List[str], use_faster: bool = False) -> str:
     """Transcribe each WAV file listed in *paths* and return the concatenated text."""
     if use_faster:
         from faster_whisper import WhisperModel
-        model = WhisperModel("base", device="cuda", compute_type="float16")
+        import torch
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        compute_type = "float16" if device == "cuda" else "int8"
+        model = WhisperModel("base", device=device, compute_type=compute_type)
         texts = []
-        for p in paths:
+        for idx, p in enumerate(paths, 1):
+            print(f"Transcribing chunk {idx}/{len(paths)}...")
             segments, _ = model.transcribe(p, language="fr", beam_size=5)
             chunk_text = "".join(seg.text for seg in segments)
             texts.append(chunk_text.strip())
     else:
         import whisper
-        model = whisper.load_model("base", device="cuda")
+        import torch
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+        model = whisper.load_model("base", device=device)
         texts = []
-        for p in paths:
+        for idx, p in enumerate(paths, 1):
+            print(f"Transcribing chunk {idx}/{len(paths)}...")
             result = model.transcribe(p, language="fr", fp16=True, beam_size=5)
             chunk_text = "".join(seg["text"] for seg in result.get("segments", []))
             texts.append(chunk_text.strip())
@@ -71,12 +86,15 @@ def transcribe_wav_in_chunks(path: str, output_path: str = "transcript.txt", chu
 
     Returns path to the transcript.
     """
-    chunk_paths = split_wav_into_chunks(path, chunk_length=chunk_length)
+    chunk_paths: List[str] = []
     try:
+        chunk_paths = split_wav_into_chunks(path, chunk_length=chunk_length)
         text = transcribe_chunks(chunk_paths, use_faster=use_faster)
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(text)
         return output_path
+    except Exception as e:
+        raise RuntimeError(f"Transcription failed: {e}") from e
     finally:
         for p in chunk_paths:
             try:


### PR DESCRIPTION
## Summary
- check that ffmpeg is available before splitting
- show progress for each chunk being transcribed
- dynamically choose CUDA or CPU for whisper models
- provide clearer error messages when ffmpeg or transcription fails

## Testing
- `python3 -m py_compile chunk_transcriber.py`

------
https://chatgpt.com/codex/tasks/task_e_684447ec859c832991d01bb3361e9967